### PR TITLE
Ajouter bouton retour dans la table des matières

### DIFF
--- a/docs/gesmouv.html
+++ b/docs/gesmouv.html
@@ -91,6 +91,13 @@
         .back-to-portal-link:hover {
             background-color: #1d4ed8; /* bg-blue-700 */
         }
+        /* Variante du bouton pour la table des matières */
+        .toc-back-link {
+            display: block;
+            width: 100%;
+            text-align: center;
+            margin-top: 1rem;
+        }
         .top-banner-logo {
             height: 2rem; /* h-8 */
         }
@@ -162,6 +169,9 @@
                         <li><a href="#historique-versions" class="hover:text-blue-600 hover:underline">4. Historique des Versions</a></li>
                         <li><a href="#support" class="hover:text-blue-600 hover:underline">5. Support et Contact</a></li>
                     </ul>
+                    <a href="../index.html" class="back-to-portal-link toc-back-link">
+                        <i class="fas fa-arrow-left mr-2"></i> Retour au Portail des Applications
+                    </a>
                 </nav>
             </aside>
 

--- a/docs/gesprat.html
+++ b/docs/gesprat.html
@@ -98,6 +98,13 @@
         .back-to-portal-link:hover {
             background-color: #1d4ed8; /* bg-blue-700 */
         }
+        /* Variante du bouton pour la table des matières */
+        .toc-back-link {
+            display: block;
+            width: 100%;
+            text-align: center;
+            margin-top: 1rem;
+        }
         .top-banner-logo {
             height: 2rem; /* h-8 */
         }
@@ -174,6 +181,9 @@
                         <li><a href="#historique-versions" class="hover:text-blue-600 hover:underline">6. Historique des Versions</a></li>
                         <li><a href="#support" class="hover:text-blue-600 hover:underline">7. Support et Contact</a></li>
                     </ul>
+                    <a href="../index.html" class="back-to-portal-link toc-back-link">
+                        <i class="fas fa-arrow-left mr-2"></i> Retour au Portail des Applications
+                    </a>
                 </nav>
             </aside>
 


### PR DESCRIPTION
## Résumé
- ajout d'une classe `.toc-back-link` dans chaque page de documentation
- insertion du bouton "Retour au Portail des Applications" directement dans la table des matières pour `gesmouv.html` et `gesprat.html`

## Tests
- `git status --short`